### PR TITLE
fix(home-assistant): strip Cookie on Frigate notification proxy path

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -115,6 +115,24 @@ spec:
         hostnames:
           - hass.mcgrath.nz
         rules:
+          # Strip heavy headers on the unauthenticated Frigate notification
+          # proxy path. HA's proxy lib forwards all request headers (minus
+          # Host/Auth/CL) to Frigate, whose nginx uses default 8k header
+          # buffers and returns 400 when a Cookie line exceeds that via
+          # Cloudflare (cf-access-jwt, large cookie jars, etc.).
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /api/frigate/notifications/
+            filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Cookie
+                    - Referer
+            backendRefs:
+              - identifier: app
+                port: http
           - backendRefs:
               - identifier: app
                 port: http


### PR DESCRIPTION
HA's unauthenticated /api/frigate/notifications/ proxy forwards all incoming request headers (minus Host/Auth/Content-Length) to Frigate. Via Cloudflare, the browser's cookie jar plus CF/envoy headers pushed request header lines past Frigate's nginx default 8k buffer, causing 400 Bad Request at parse time. Internal access stayed under the limit.

Drop Cookie and Referer at envoy-external for this path only.