### PR TITLE
fix(hermes): create brew var dir in initContainer

### DIFF
--- a/kubernetes/apps/default/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hermes/app/helmrelease.yaml
@@ -66,6 +66,11 @@ spec:
                   mkdir -p $HOMEBREW_PREFIX
                   git clone --depth 1 https://github.com/Homebrew/brew $HOMEBREW_PREFIX
                 fi
+
+                # Ensure brew's lock dir exists — brew creates it on first run but
+                # only if the parent tree is writable. Without this, brew fails on
+                # a fresh PVC before the first `brew install`.
+                mkdir -p /opt/data/.local/homebrew/var/homebrew/locks
         containers:
           app:
             image: *image


### PR DESCRIPTION
Brew's lock directory (`/opt/data/.local/homebrew/var/homebrew/locks`) doesn't exist on a fresh PVC, causing `brew install` to fail. This adds a `mkdir -p` in the initContainer so it's always present before the main container starts.