### PR TITLE
fix(hermes): remove --replace flag from gateway args

### DIFF
--- a/kubernetes/apps/default/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hermes/app/helmrelease.yaml
@@ -77,7 +77,6 @@ spec:
             args:
               - gateway
               - run
-              - --replace
             env:
               TZ: &tz Pacific/Auckland
               API_SERVER_ENABLED: true
@@ -108,10 +107,18 @@ spec:
               - secretRef:
                   name: hermes-secret
             probes:
-              liveness:
-                enabled: false
-              readiness:
-                enabled: false
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
               startup:
                 enabled: false
             securityContext:


### PR DESCRIPTION
The `--replace` flag is for rolling-restart takeovers — killing an already-running gateway and replacing it. In this setup the gateway runs as the container's main program (via s6-overlay `rc.init top`), so there's never an existing instance to replace on startup. Removing it is cleaner and triggers a pod recreation to pick up recent config changes.