### PR TITLE
fix(hermes): enable browser tool on Talos via --no-sandbox

### DIFF
--- a/kubernetes/apps/default/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hermes/app/helmrelease.yaml
@@ -103,6 +103,15 @@ spec:
               HOMEBREW_REPOSITORY: /opt/data/.local/homebrew
               PATH: /opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:/opt/data/.local/go/bin:/opt/data/.local/homebrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
               PIP_BREAK_SYSTEM_PACKAGES: "1"
+              # Talos Linux disables unprivileged user namespaces at the kernel
+              # level (no AppArmor userns file, just a kernel-level restriction).
+              # Hermes auto-detects the Ubuntu/AppArmor variant via
+              # /proc/sys/kernel/apparmor_restrict_unprivileged_userns, but that
+              # file doesn't exist on Talos — so auto-detection falls through and
+              # Chrome exits with "No usable sandbox!". Setting AGENT_BROWSER_ARGS
+              # directly bypasses auto-detection and forces --no-sandbox for every
+              # browser launch.
+              AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
             envFrom:
               - secretRef:
                   name: hermes-secret


### PR DESCRIPTION
## Problem

The Hermes browser tool (`browser_navigate`, `browser_click`, etc.) fails in this cluster with:

```
FATAL: No usable sandbox! ... Chrome exited before providing DevTools URL
```

## Root Cause

Talos Linux disables unprivileged user namespaces at the kernel level. Hermes has auto-detection logic for this in `browser_tool.py` — it checks `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` (the Ubuntu/AppArmor variant) and also checks if running as root. Neither condition is true here:

- We run as uid 10000 (not root)
- `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` does not exist on Talos

So auto-detection falls through and Chrome is launched *without* `--no-sandbox`, causing the fatal exit.

## Fix

Set `AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage` in the pod env. Hermes checks this env var *before* auto-detection, so it short-circuits cleanly. This is the documented override mechanism (`AGENT_BROWSER_ARGS` is read at line ~2020 of `browser_tool.py`).

`--disable-dev-shm-usage` is included alongside `--no-sandbox` as it's the standard companion flag for containerised Chrome (prevents crashes when `/dev/shm` is too small).