### PR TITLE
feat(hermes): enable Home Assistant toolset

### DIFF
--- a/kubernetes/apps/default/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/default/hermes/app/externalsecret.yaml
@@ -25,7 +25,8 @@ spec:
         DISCORD_HOME_CHANNEL: "{{ .DISCORD_HOME_CHANNEL }}"
         DISCORD_HOME_CHANNEL_NAME: Bingle
 
-        HOME_ASSISTANT_TOKEN: "{{ .HOME_ASSISTANT_TOKEN }}"
+        HASS_TOKEN: "{{ .HOME_ASSISTANT_TOKEN }}"
+        HASS_URL: "http://home-assistant.default.svc.cluster.local:8123"
 
   dataFrom:
     - extract:

--- a/kubernetes/apps/default/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/default/hermes/app/resources/config.yaml
@@ -15,7 +15,8 @@ terminal:
   persistent_shell: true
   env_passthrough:
     - GH_TOKEN
-    - HOME_ASSISTANT_TOKEN
+    - HASS_TOKEN
+    - HASS_URL
 memory:
   memory_enabled: true
   user_profile_enabled: true
@@ -36,6 +37,7 @@ security:
 platform_toolsets:
   cli:
     - hermes-cli
+    - homeassistant
   discord:
     - hermes-discord
 agent:

--- a/kubernetes/apps/default/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/default/hermes/app/resources/config.yaml
@@ -51,6 +51,7 @@ agent:
 discord:
   require_mention: false
   auto_thread: false
+  reactions: false
 group_sessions_per_user: true
 # auxiliary:
 #   vision:

--- a/kubernetes/apps/default/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/default/hermes/app/resources/config.yaml
@@ -40,6 +40,7 @@ platform_toolsets:
     - homeassistant
   discord:
     - hermes-discord
+    - homeassistant
 agent:
   max_turns: 90
   gateway_timeout: 1800


### PR DESCRIPTION
## Summary

Enables the built-in Hermes Home Assistant toolset so Hermes can query and control Home Assistant directly.

## Changes

### `externalsecret.yaml`
- Rename `HOME_ASSISTANT_TOKEN` → `HASS_TOKEN` to match the env var name the Hermes `homeassistant` toolset expects
- Add `HASS_URL` pointing to the cluster-internal service (`http://home-assistant.default.svc.cluster.local:8123`)

### `resources/config.yaml`
- Add `homeassistant` to `platform_toolsets.cli`
- Update `terminal.env_passthrough` to use `HASS_TOKEN` / `HASS_URL` (renamed from `HOME_ASSISTANT_TOKEN`)

## Notes
- The 1Password item key stays `HOME_ASSISTANT_TOKEN` — only the K8s Secret key name changes
- `HASS_URL` uses the cluster-internal address to avoid unnecessary egress through the external gateway
- Pod restart required after Flux reconciles for the new Secret keys to be injected